### PR TITLE
Build 👷: Remove version specification for pnpm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## build 👷: Remove version specification for pnpm setup

- .github/workflows/release.yml: Removed the version specification for the pnpm setup step to use the latest version by default. This change simplifies the configuration and ensures that the workflow uses the most up-to-date features and fixes available in pnpm.

## ci 🚀: Add permissions for GitHub Actions to enable write access

- .github/workflows/release.yml: Added permissions section to grant write access for the contents, ensuring the workflow can perform necessary actions during the release process.