### PR TITLE
Chore: Deprecated SHA256

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: sha256
         run: |
           sha256sum bob-plugin-ollama-ocr-${{ github.ref_name }}.bobplugin > checksum.txt
-          echo "sha256=$(cat checksum.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "sha256=$(cut -d' ' -f1 checksum.txt)" >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: actions/create-release@v1


### PR DESCRIPTION
## 👷 Update deprecated:

The `Calculate SHA256` step in workflow has been updated to use the new environment file method (`$GITHUB_OUTPUT`) instead of the deprecated `set-output` command. This will prevent deprecation errors and keep your workflow future-proof.